### PR TITLE
Make use the default pool of a host or a cluster

### DIFF
--- a/lib/chef/knife/BaseVsphereCommand.rb
+++ b/lib/chef/knife/BaseVsphereCommand.rb
@@ -138,7 +138,9 @@ class Chef
 						end
 					end
 				end
-				baseEntity
+
+        baseEntity = baseEntity.resourcePool if not baseEntity.is_a?(RbVmomi::VIM::ResourcePool) and baseEntity.respond_to?(:resourcePool)
+        baseEntity
 			end
 
 			def find_datastore(dsName)


### PR DESCRIPTION
Named resource pools are not always used in vsphere installations. 

This patch allows the --resource-pool option of the clone command to take the name of a host (cluster), and the cloned VM will be put into default unnamed resource pool of the host (cluster).
