### PR TITLE
Fix --cvlan handling when VC is not using a distributed switch

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -389,7 +389,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
 	rescue Errno::ECONNREFUSED
 		sleep 2
 		false
-	rescue Errno::EHOSTUNREACH
+	rescue Errno::EHOSTUNREACH, Errno::ENETUNREACH
 		sleep 2
 		false
 	ensure


### PR DESCRIPTION
Basically, it requires setting the device using the network name instead of the switch port.

Also includes a smallish change to handle Errno::ENETUNREACH the same way as Errno::EHOSTUNREACH.
