### PR TITLE
Add support for executing a program in the guest OS.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -111,6 +111,22 @@ Unregisters an existing VM. Currently, it does not perform any datastore cleanup
 
 Lists all known datastores with capacity and usage
 
+== knife vsphere vm execute VMNAME COMMAND [ARGUMENTS] --exec-user USER --exec-passwd PASSWD [ --exec-dir DIRECTORY ]
+
+Executes a program on the guest. Requires vCenter 5.0 or higher. 
+
+Command path must be absolute. For Linux guest operating systems,
+/bin/bash is used to start the program. For Solaris guest operating
+systems, /bin/bash is used to start the program if it
+exists. Otherwise /bin/sh is used.
+
+Arguments are optional, and allow for redirection in Linux and Solaris.
+
+  --exec-user USERNAME - The username on the guest to execute as.
+  --exec-passwd PASSWD - The password for the user executing as.
+  --exec-dir DIRECTORY - Optional: Working directory to execute in. Will default to $HOME of user.
+
+
 = LICENSE:
 
 Authors:: Ezra Pagel <ezra@cpan.org>

--- a/lib/chef/knife/vsphere_vm_execute.rb
+++ b/lib/chef/knife/vsphere_vm_execute.rb
@@ -1,0 +1,68 @@
+
+# Author:: Ian Delahorne (<ian@delahorne.com>)
+# License:: Apache License, Version 2.0
+
+require 'chef/knife'
+require 'chef/knife/BaseVsphereCommand'
+require 'rbvmomi'
+require 'netaddr'
+
+class Chef::Knife::VsphereVmExecute < Chef::Knife::BaseVsphereCommand
+  banner "knife vsphere vm execute VMNAME COMMAND ARGS"
+
+  option :exec_user, 
+    :long => "--exec-user USER",
+    :description => "User to execute as",
+    :required => true
+
+  option :exec_passwd,
+    :long => "--exec-passwd PASSWORD",
+    :description => "Password for execute user",
+    :required => true
+  
+  option :exec_dir, 
+    :long => "--exec-dir DIRECTORY",
+    :description => "Working directory to execute in"
+
+  get_common_options
+  
+  def run
+    $stdout.sync = true
+    vmname = @name_args[0]
+    if vmname.nil?
+      show_usage
+      fatal_exit("You must specify a virtual machine name")
+    end
+    command = @name_args[1]
+    if command.nil?
+      show_usage
+      fatal_exit("You must specify a command to execute")
+    end
+
+    args = @name_args[2]
+    if args.nil?
+      args = ""
+    end
+    
+    vim = get_vim_connection
+
+    dcname = get_config(:vsphere_dc)
+    dc = vim.serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+    folder = find_folder(get_config(:folder)) || dc.vmFolder
+    
+    vm = find_in_folder(folder, RbVmomi::VIM::VirtualMachine, vmname) or
+      abort "VM #{vmname} not found"
+ 
+    gom = vim.serviceContent.guestOperationsManager
+
+    guest_auth = RbVmomi::VIM::NamePasswordAuthentication(:interactiveSession => false, 
+                                                          :username => config[:exec_user],
+                                                          :password => config[:exec_passwd])
+    prog_spec = RbVmomi::VIM::GuestProgramSpec(:programPath => command,
+                                               :arguments => args,
+                                               :workingDirectory => get_config(:exec_dir))
+    
+    gom.processManager.StartProgramInGuest(:vm => vm, :auth => guest_auth, :spec => prog_spec)
+
+  end
+end


### PR DESCRIPTION
Use the vSphere 5.0 API call GuestProcessManager::StartProgramInGuest
to execute a program in a guest that has VMware Tools
installed. Currently only supports user/password authentication. Only
tested on Linux guests.

Hat-tip to Randy Van Fossan vanfossr@oclc.org for pointing out the
need for this.
