### PR TITLE
Add --wait-port option to vm state command

### DIFF
--- a/lib/chef/knife/BaseVsphereCommand.rb
+++ b/lib/chef/knife/BaseVsphereCommand.rb
@@ -175,6 +175,29 @@ class Chef
 				exit 1
 			end
 
+			def tcp_test_port(hostname,port)
+			  tcp_socket = TCPSocket.new(hostname, port)
+			  readable = IO.select([tcp_socket], nil, nil, 5)
+			  if readable
+			    Chef::Log.debug("sshd accepting connections on #{hostname}, banner is #{tcp_socket.gets}") if port == 22
+			    true
+			  else
+			    false
+			  end
+			  rescue Errno::ETIMEDOUT
+			    false
+			  rescue Errno::EPERM
+			    false
+			  rescue Errno::ECONNREFUSED
+			    sleep 2
+			    false
+			  rescue Errno::EHOSTUNREACH, Errno::ENETUNREACH
+			    sleep 2
+			    false
+			  ensure
+			    tcp_socket && tcp_socket.close
+			end
+			
 		end
 	end
 end

--- a/lib/chef/knife/vsphere_vm_state.rb
+++ b/lib/chef/knife/vsphere_vm_state.rb
@@ -30,6 +30,11 @@ class Chef::Knife::VsphereVmState < Chef::Knife::BaseVsphereCommand
   :long => "--state STATE",
   :description => "The power state to transition the VM into; one of on|off|suspended"
 
+  option :wait_port,
+    :short => "-w PORT",
+    :long => "--wait-port PORT",
+    :description => "Wait for VM to be accessible on a port"
+
   def run
   
     $stdout.sync = true
@@ -79,6 +84,12 @@ class Chef::Knife::VsphereVmState < Chef::Knife::BaseVsphereCommand
       when 'reset'
         vm.ResetVM_Task.wait_for_completion
         puts "Reset virtual machine #{vmname}"
+      end
+
+      if get_config(:wait_port)
+        print "Waiting for port #{get_config(:wait_port)}..."
+        print "." until tcp_test_port(vmname,get_config(:wait_port))
+        puts "done"
       end
     end
   end


### PR DESCRIPTION
Useful when chaining commands that might require system to be responding.
