### PR TITLE
Added Automatic LUN selection and auto creation of LSILogic SCSI Adapters

### DIFF
--- a/lib/chef/knife/BaseVsphereCommand.rb
+++ b/lib/chef/knife/BaseVsphereCommand.rb
@@ -209,7 +209,7 @@ class Chef
                           if candidates.length > 0
                             vmdk_datastore = candidates[0]
                           else
-                            puts "Insufficient space on all LUNs currently assigned to #{vmname}. Please specify a new target."
+                            puts "Insufficient space on all LUNs designated or assigned to the virtual machine. Please specify a new target."
                             vmdk_datastore = nil
                           end
                           return vmdk_datastore

--- a/lib/chef/knife/vsphere_vm_vmdk_add.rb
+++ b/lib/chef/knife/vsphere_vm_vmdk_add.rb
@@ -53,9 +53,11 @@ class Chef::Knife::VsphereVmVmdkAdd < Chef::Knife::BaseVsphereCommand
 
     if target_lun.nil?
       vmdk_datastore = choose_datastore(vm.datastore,size)
+      exit -1 if vmdk_datastore.nil?
     else
         vmdk_datastores = find_datastores_regex(target_lun)
         vmdk_datastore = choose_datastore(vmdk_datastores,size)
+        exit -1 if vmdk_datastore.nil?
         vmdk_dir  = "[#{vmdk_datastore.name}] #{vmname}"
         # create the vm folder on the LUN or subsequent operations will fail.
         if not vmdk_datastore.exists? vmname


### PR DESCRIPTION
Running:
  knife vsphere vm vmdk add --vmdk-type thick host.example.org 50GB
will now search all of the LUNs associated with the VM for available space, not just the first one, and will choose the first one that has the available space, but not exceed 90%

Running:
  knife vsphere vm vmdk add --vmdk-type thick --target-lun "LUN_60_Lab_Packages" host.example.org 50GB
will now put the vmdk on the specified LUN, making the vm directory if it doesn't exist.

Running:
  knife vsphere vm vmdk add --vmdk-type thick --target-lun "LUN_[0-9]+_Lab_Packages" host.example.org 50GB
will now use a regex on --target-lun to put the vmdk on the first LUN that matches the pattern and has the space available, but will not exceed 90% so snapshots may still be used.

LSILogic SCSI controllers will be added as needed, until you hit 4 controllers and 60 vmdks, which is the current limit of ESX.

By repeatedly running 
  knife vsphere vm vmdk add --vmdk-type thick --target-lun "LUN_[0-9]+_Lab_Packages" host.example.org 50GB
you can just keep adding storage to a vm until you hit the  ESX device limit.
