### PR TITLE
Add -l/--log_level switch to knife vsphere vm clone

### DIFF
--- a/knife-vsphere.gemspec
+++ b/knife-vsphere.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "knife-vsphere"
-  s.version = "0.7.1"
+  s.version = "0.7.0"
   s.summary = "vSphere Support for Knife"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=


### PR DESCRIPTION
Allows user to specify the log level for chef-client when using the --bootstrap option. 
