### PR TITLE
removed the default distro parameter

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -151,7 +151,6 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
 		:short => "-d DISTRO",
 		:long => "--distro DISTRO",
 		:description => "Bootstrap a distro using a template"
-	$default[:distro] = "ubuntu10.04-gems"
 
 	option :template_file,
 		:long => "--template-file TEMPLATE",


### PR DESCRIPTION
As it is implemented now it's not possible to specify a template-file option since there is a default on the --distro option and bootstrap prioritizes the distro option over the template-file option.  This change simply removes the default value from the distro option.
