### PR TITLE
update readme to reflect behavior of vm.destroy_task and --purge option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -130,7 +130,7 @@ class KnifeVspherePlugin
   end
 end
 
-== knife vsphere vm delete VMNAME> [--purge]
+== knife vsphere vm delete VMNAME [--purge]
 
 Deletes an existing VM, removing it from vSphere inventory and deleting from disk, optionally deleting it from Chef as well.
     --purge           - Delete the client and node from Chef as well


### PR DESCRIPTION
vm.destroy_task does indeed delete the vm from disk. added arg definition for --purge too
