### PR TITLE
Handle parent class of ClusterComputeResource.

### DIFF
--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -167,7 +167,7 @@ class Chef
             if baseEntity.is_a? RbVmomi::VIM::Folder
               baseEntity = baseEntity.childEntity.find { |f| f.name == entityArrItem } or
                   abort "no such pool #{poolName} while looking for #{entityArrItem}"
-            elsif baseEntity.is_a? RbVmomi::VIM::ClusterComputeResource
+            elsif baseEntity.is_a? RbVmomi::VIM::ClusterComputeResource or baseEntity.is_a? RbVmomi::VIM::ComputeResource
               baseEntity = baseEntity.resourcePool.resourcePool.find { |f| f.name == entityArrItem } or
                   abort "no such pool #{poolName} while looking for #{entityArrItem}"
             elsif baseEntity.is_a? RbVmomi::VIM::ResourcePool
@@ -245,7 +245,7 @@ class Chef
       end
 
       def find_all_in_folder(folder, type)
-        if folder.instance_of?(RbVmomi::VIM::ClusterComputeResource)
+        if folder.instance_of?(RbVmomi::VIM::ClusterComputeResource) or folder.instance_of?(RbVmomi::VIM::ComputeResource)
           folder = folder.resourcePool
         end
         if folder.instance_of?(RbVmomi::VIM::ResourcePool)


### PR DESCRIPTION
I'm not super familiar with the vsphere api or rbvmomi but I'm getting some complaints about unknown types in listing pools. Seems the api is returning ComputeResources instead of the expected ClusterComputeResource. As ClusterComputeResource extends ComputeResouce I let it match it.

```
Switched to branch 'master'
mkent@mbp master ~/git/knife-vsphere> knife vsphere pool list
Folder:
ComputeResource: 10.10.0.36
Unknown type ComputeResource, not enumerating
ComputeResource: 10.10.0.35
Unknown type ComputeResource, not enumerating
ComputeResource: 10.10.0.37
Unknown type ComputeResource, not enumerating
mkent@mbp master ~/git/knife-vsphere> git checkout fix-compute-ref
Switched to branch 'fix-compute-ref'
mkent@mbp fix-compute-ref ~/git/knife-vsphere> knife vsphere pool list
Folder:
ComputeResource: 10.10.0.36
ComputeResource: 10.10.0.35
ComputeResource: 10.10.0.37
```
