### PR TITLE
change how the datacenter is found

### DIFF
--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -133,12 +133,12 @@ class Chef
       end
 
       def get_datacenter
-        dc = config[:vim].serviceInstance.find_datacenter(get_config(:vsphere_dc)) or abort "datacenter not found"
+        dcname = get_config(:vsphere_dc)
+        config[:vim].rootFolder.children.find { |child| child.name == dcname && child.class == RbVmomi::VIM::Datacenter } or abort "datacenter not found"
       end
 
       def find_folder(folderName)
-        dcname = get_config(:vsphere_dc)
-        dc = config[:vim].serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+        dc = get_datacenter
         baseEntity = dc.vmFolder
         entityArray = folderName.split('/')
         entityArray.each do |entityArrItem|
@@ -151,15 +151,13 @@ class Chef
       end
 
       def find_network(networkName)
-        dcname = get_config(:vsphere_dc)
-        dc = config[:vim].serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+        dc = get_datacenter
         baseEntity = dc.network
         baseEntity.find { |f| f.name == networkName } or abort "no such network #{networkName}"
       end
 
       def find_pool(poolName)
-        dcname = get_config(:vsphere_dc)
-        dc = config[:vim].serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+        dc = get_datacenter
         baseEntity = dc.hostFolder
         entityArray = poolName.split('/')
         entityArray.each do |entityArrItem|
@@ -219,8 +217,7 @@ class Chef
       def find_datastores_regex(regex)
         stores = Array.new()
         puts "Looking for all datastores that match /#{regex}/"
-        dcname = get_config(:vsphere_dc)
-        dc = config[:vim].serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+        dc = get_datacenter
         baseEntity = dc.datastore
         baseEntity.each do |ds|
           if ds.name.match /#{regex}/
@@ -231,8 +228,7 @@ class Chef
       end
 
       def find_datastore(dsName)
-        dcname = get_config(:vsphere_dc)
-        dc = config[:vim].serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+        dc = get_datacenter
         baseEntity = dc.datastore
         baseEntity.find { |f| f.info.name == dsName } or abort "no such datastore #{dsName}"
       end

--- a/lib/chef/knife/vsphere_datastore_list.rb
+++ b/lib/chef/knife/vsphere_datastore_list.rb
@@ -47,8 +47,7 @@ class Chef::Knife::VsphereDatastoreList < Chef::Knife::BaseVsphereCommand
     $stdout.sync = true
 
     vim = get_vim_connection
-    dcname = get_config(:vsphere_dc)
-    dc = config[:vim].serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+    dc = get_datacenter
     dc.datastore.each do |store|
       avail = number_to_human_size(store.summary[:freeSpace])
       cap = number_to_human_size(store.summary[:capacity])

--- a/lib/chef/knife/vsphere_pool_list.rb
+++ b/lib/chef/knife/vsphere_pool_list.rb
@@ -23,8 +23,7 @@ class Chef::Knife::VspherePoolList < Chef::Knife::BaseVsphereCommand
   end
 
   def find_pool_folder(folderName)
-    dcname = get_config(:vsphere_dc)
-    dc = config[:vim].serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+    dc = get_datacenter
     baseEntity = dc.hostFolder
     entityArray = folderName.split('/')
     entityArray.each do |entityArrItem|

--- a/lib/chef/knife/vsphere_vlan_list.rb
+++ b/lib/chef/knife/vsphere_vlan_list.rb
@@ -28,8 +28,7 @@ class Chef::Knife::VsphereVlanList < Chef::Knife::BaseVsphereCommand
     $stdout.sync = true
 
     vim = get_vim_connection
-    dcname = get_config(:vsphere_dc)
-    dc = config[:vim].serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+    dc = get_datacenter
     dc.network.each do |network|
       puts "#{ui.color("VLAN", :cyan)}: #{network.name}"
     end

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -212,8 +212,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
 
     vim = get_vim_connection
 
-    dcname = get_config(:vsphere_dc)
-    dc = vim.serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+    dc = get_datacenter
 
     src_folder = find_folder(get_config(:folder)) || dc.vmFolder
 
@@ -261,8 +260,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     if get_config(:resource_pool)
       rspec = RbVmomi::VIM.VirtualMachineRelocateSpec(:pool => find_pool(get_config(:resource_pool)))
     else
-      dcname = get_config(:vsphere_dc)
-      dc = config[:vim].serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+      dc = get_datacenter
       hosts = find_all_in_folder(dc.hostFolder, RbVmomi::VIM::ComputeResource)
       rp = hosts.first.resourcePool
       rspec = RbVmomi::VIM.VirtualMachineRelocateSpec(:pool => rp)

--- a/lib/chef/knife/vsphere_vm_config.rb
+++ b/lib/chef/knife/vsphere_vm_config.rb
@@ -34,8 +34,7 @@ class Chef::Knife::VsphereVmConfig < Chef::Knife::BaseVsphereCommand
 
     vim = get_vim_connection
 
-    dcname = get_config(:vsphere_dc)
-    dc = vim.serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+    dc = get_datacenter
     folder = find_folder(get_config(:folder)) || dc.vmFolder
 
     vm = find_in_folder(folder, RbVmomi::VIM::VirtualMachine, vmname) or

--- a/lib/chef/knife/vsphere_vm_execute.rb
+++ b/lib/chef/knife/vsphere_vm_execute.rb
@@ -45,8 +45,7 @@ class Chef::Knife::VsphereVmExecute < Chef::Knife::BaseVsphereCommand
 
     vim = get_vim_connection
 
-    dcname = get_config(:vsphere_dc)
-    dc = vim.serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+    dc = get_datacenter
     folder = find_folder(get_config(:folder)) || dc.vmFolder
 
     vm = find_in_folder(folder, RbVmomi::VIM::VirtualMachine, vmname) or

--- a/lib/chef/knife/vsphere_vm_query.rb
+++ b/lib/chef/knife/vsphere_vm_query.rb
@@ -27,8 +27,7 @@ class Chef::Knife::VsphereVmQuery < Chef::Knife::BaseVsphereCommand
 
     vim = get_vim_connection
 
-    dcname = get_config(:vsphere_dc)
-    dc = vim.serviceInstance.find_datacenter(dcname) or abort "datacenter not found"
+    dc = get_datacenter
     folder = find_folder(get_config(:folder)) || dc.vmFolder
 
     vm = find_in_folder(folder, RbVmomi::VIM::VirtualMachine, vmname) or


### PR DESCRIPTION
Instead of using `serviceInstance.find_datacenter` to find the datacenter by name, loop through `rootFolder.children` looking for a child that has that name and is a datacenter.

The reason to do this is that `rootFolder.children` is populated with the children that the user has permissions to see. `serviceInstance.find_datacenter` does `rootFolder.traverse` which requires the permission to search through all the children
