### PR TITLE
Added support for datacenters in subfolders

### DIFF
--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -143,9 +143,22 @@ class Chef
         return @vm
       end
 
+      def traverse_folders_for_dc(folder, dcname)
+        children = folder.children.find_all
+        children.each do |child|
+          if child.class == RbVmomi::VIM::Datacenter && child.name == dcname
+            return child
+          elsif child.class == RbVmomi::VIM::Folder
+            dc = traverse_folders_for_dc(child, dcname)
+            if dc then return dc end
+          end
+        end
+        return false
+      end
+
       def get_datacenter
         dcname = get_config(:vsphere_dc)
-        config[:vim].rootFolder.children.find { |child| child.name == dcname && child.class == RbVmomi::VIM::Datacenter } or abort "datacenter not found"
+        traverse_folders_for_dc(config[:vim].rootFolder, dcname) or abort "datacenter not found"
       end
 
       def find_folder(folderName)


### PR DESCRIPTION
As mentioned here: https://github.com/ezrapagel/knife-vsphere/pull/69
Datacenters in subfolders cannot be found. I've patched this to traverse all folders looking for the specified datacenter.

Caveat: If you previously specified your datacenter in knife.rb as something like "North America/Texas DC", you should now only use "Texas DC". Obviously this won't work if you have two datacenters with the same name in different folders, but I'm not sure if VMWare even allows that.
