### PR TITLE
Fix exception from vsphere_datastore_maxfree.rb:30: undefined method `[]=' for nil:NilClass (NoMethodError)

### DIFF
--- a/lib/chef/knife/vsphere_datastore_maxfree.rb
+++ b/lib/chef/knife/vsphere_datastore_maxfree.rb
@@ -27,9 +27,9 @@ class Chef::Knife::VsphereDatastoreMaxfree < Chef::Knife::BaseVsphereCommand
          :short => "-r REGEX",
          :long => "--regex REGEX",
          :description => "Regex to match the datastore name"
-  $default[:regex] = ''
 
   get_common_options
+  $default[:regex] = ''
 
   def run
     $stdout.sync = true


### PR DESCRIPTION
This problem happened intermittently on my environment, because the $default var is accessed before init.
