### PR TITLE
moved datacenter param to capital D to avoid conflicts with distro

### DIFF
--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -42,7 +42,7 @@ class Chef
                :description => "The vsphere host"
 
         option :vsphere_dc,
-               :short => "-d DATACENTER",
+               :short => "-D DATACENTER",
                :long => "--vsdc DATACENTER",
                :description => "The Datacenter for vsphere"
 


### PR DESCRIPTION
distro short param was -d which would cause knife to read this as the datastore instead of the distro.

Moved datacenter to capital D so that -d is in line with basic knife distro
