### PR TITLE
Issue #100 Customization plugin call is called to early

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -393,11 +393,11 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
         cust_spec.identity = ident
       end
 
+      clone_spec.customization = cust_spec
+
       if customization_plugin && customization_plugin.respond_to?(:customize_clone_spec)
         clone_spec = customization_plugin.customize_clone_spec(src_config, clone_spec)
       end
-
-      clone_spec.customization = cust_spec
     end
     clone_spec
   end


### PR DESCRIPTION
As I mentioned in Issue #100 description custiomization plugin call is made to early. 

It means, that i.e. when I want to create my own Windows style customization object with proper identity, all my changes I've made are overwritten by default Linux style customization.

Customization plugin has to have ability to modify all prepared configuration and override any property.
