### PR TITLE
Ensure that a VirtualEthernetCardNetworkBackingInfo is created when atta...

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -375,7 +375,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
         card.backing.port = switch_port
       rescue
         # not connected to a distibuted switch?
-        card.backing.deviceName = network.name
+        card.backing = RbVmomi::VIM::VirtualEthernetCardNetworkBackingInfo(:network => network, :deviceName => network.name)
       end
       dev_spec = RbVmomi::VIM.VirtualDeviceConfigSpec(:device => card, :operation => "edit")
       clone_spec.config.deviceChange.push dev_spec


### PR DESCRIPTION
...ching to an Standard Switch Network.

This solves the follow execption, that I think is caused when the template
was created on a different kind of network.

Exception:

```
/home/keymon/.chefdk/gem/ruby/2.1.0/gems/knife-vsphere-0.9.9/lib/chef/knife/vsphere_vm_clone.rb:337:in `rescue in generate_clone_spec': undefined method `deviceName=' for #<RbVmomi::VIM::VirtualEthernetCardDistributedVirtualPortBackingInfo:0x00000004a015f0> (NoMethodError)
    from /home/keymon/.chefdk/gem/ruby/2.1.0/gems/knife-vsphere-0.9.9/lib/chef/knife/vsphere_vm_clone.rb:332:in `generate_clone_spec'
    from /home/keymon/.chefdk/gem/ruby/2.1.0/gems/knife-vsphere-0.9.9/lib/chef/knife/vsphere_vm_clone.rb:231:in `run'
    from /opt/chefdk/embedded/apps/chef/lib/chef/knife.rb:493:in `run_with_pretty_exceptions'
    from /opt/chefdk/embedded/apps/chef/lib/chef/knife.rb:174:in `run'
    from /opt/chefdk/embedded/apps/chef/lib/chef/application/knife.rb:139:in `run'
    from /opt/chefdk/embedded/apps/chef/bin/knife:25:in `<top (required)>'
    from /usr/bin/knife:34:in `load'
    from /usr/bin/knife:34:in `<main>'
```
