### PR TITLE
allows modifying properties in vm.tools

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -223,6 +223,15 @@ Customization Plugin Example:
         "timeZone": "100"
     }
 
+== knife vsphere vm toolsconfig PROPERTY VALUE [--empty]
+    --empty           - allows clearing string properties
+
+Sets properties in tools property.
+See \"https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.ToolsConfigInfo.html\" for available properties and types.
+
+Examples:
+    knife vsphere vm toolsconfig myvirtualmachine syncTimeWithHost false
+    knife vsphere vm toolsconfig myvirtualmachine pendingCustomization -e
 
 == knife vsphere vm delete VMNAME [--purge]
 

--- a/lib/chef/knife/vsphere_vm_toolsconfig.rb
+++ b/lib/chef/knife/vsphere_vm_toolsconfig.rb
@@ -1,0 +1,52 @@
+# Author:: Malte Heidenreich
+# License:: Apache License, Version 2.0
+
+require 'chef/knife'
+require 'chef/knife/base_vsphere_command'
+require 'rbvmomi'
+require 'netaddr'
+
+class Chef::Knife::VsphereVmToolsconfig < Chef::Knife::BaseVsphereCommand
+  banner "knife vsphere vm toolsconfig PROPERTY VALUE. See \"https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.ToolsConfigInfo.html\" for available properties and types."
+
+  option :empty,
+         :short => "-e",
+         :long => "--empty",
+         :description => "Allow empty string"
+  get_common_options
+
+  def run
+    $stdout.sync = true
+    vmname = @name_args[0]
+    if vmname.nil?
+      show_usage
+      fatal_exit("You must specify a virtual machine name")
+    end
+
+    property = @name_args[1]
+    if property.nil?
+      show_usage
+      fatal_exit("You must specify a property to modify")
+    end
+
+    value = @name_args[2]
+    if value.nil? && !get_config(:empty)
+      show_usage
+      fatal_exit("You must specify a value")
+    end
+
+    value = "" if get_config(:empty)
+
+    vim = get_vim_connection
+
+    dc = get_datacenter
+    folder = find_folder(get_config(:folder)) || dc.vmFolder
+
+    vm = traverse_folders_for_vm(folder, vmname) or abort "VM #{vmname} not found"
+
+    vmConfigSpec = RbVmomi::VIM.VirtualMachineConfigSpec(:tools => RbVmomi::VIM.ToolsConfigInfo(property => value))
+    vm.ReconfigVM_Task(:spec => vmConfigSpec)
+
+    puts "property #{property} updated successfully"
+  end
+end


### PR DESCRIPTION
Generic command for modifying properties in vm.config.tools

PLUS:
You can disable VMware Image Customization after every power cycle with

`knife vsphere vm toolsconfig myvirtualmachine pendingCustomization -e`

See:
https://communities.vmware.com/thread/286939
and
http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2078352
