### PR TITLE
environment option for vm clone.

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -113,6 +113,10 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
          :description => "Indicates whether to bootstrap the VM",
          :boolean => false
 
+  option :environment,
+         :long => "--environment ENVIRONMENT",
+         :description => "Environment to add the node to for bootstrapping"
+
   option :fqdn,
          :long => "--fqdn SERVER_FQDN",
          :description => "Fully qualified hostname for bootstrapping"


### PR DESCRIPTION
adds the node to the specified environment when bootstrapping.

Rest of the code is already there but the actual option was missing from vm clone
(not in get_common_options, and I'm not sure it if it should be...)
