### PR TITLE
Fix issue where snapshot could not be found if a sibling snapshot contai...

### DIFF
--- a/lib/chef/knife/vsphere_vm_snapshot.rb
+++ b/lib/chef/knife/vsphere_vm_snapshot.rb
@@ -106,6 +106,7 @@ class Chef::Knife::VsphereVmSnapshot < Chef::Knife::BaseVsphereCommand
     tree.each do |node|
       if node.name == name
         snapshot = node.snapshot
+        break
       elsif !node.childSnapshotList.empty?
         snapshot = find_node(node.childSnapshotList, name)
       end


### PR DESCRIPTION
Fixes the following issue:

Given a tree like this:

+--parent_snapshot1
+--parent_snapshot2
+--+--child_snapshot2

find_node will return 'nil' when searching for 'parent_snapshot1' because the tree will iterate to parent_snapshot2, which has children, which will cause the recursive call on old line 110 to be called and return 'nil'.
