### PR TITLE
Fix handling of program args in vsphere vm execute.

### DIFF
--- a/lib/chef/knife/vsphere_vm_execute.rb
+++ b/lib/chef/knife/vsphere_vm_execute.rb
@@ -43,7 +43,7 @@ class Chef::Knife::VsphereVmExecute < Chef::Knife::BaseVsphereCommand
     end
 
     args = @name_args
-    args = "" if args.nil? || args.empty?
+    args = [] if args.nil?
 
     vm = get_vm_by_name(vmname, get_config(:folder)) || fatal_exit("Could not find #{vmname}")
 


### PR DESCRIPTION
Signed-off-by: Skip Sopscak <dsopscak@gmail.com>

### Description

<!--- Describe what this change achieves--->
Corrects handling of program args in case there are none. It was erroneously set to an empty string which caused a subsequent exception when join was called on the string object. This keeps the object as an array up to the join.

### Issues Resolved

<!--- List any existing issues this PR resolves--->
467

### Check List

- [ ] All tests pass.
- [ ] All style checks pass.
- [ ] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
