### PR TITLE
trivial update to vm-state options

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ $ knife vsphere vm find --snapshots --full-path --cpu --ram --esx-disk \
 Manage power state of a virtual machine, aka turn it off and on
 
 ```bash
--s STATE, --state STATE    - The power state to transition the VM into; one of on|off|suspended|reboot
+-s STATE, --state STATE    - The power state to transition the VM into; one of on|off|suspend|reboot
 -w PORT, --wait-port PORT  - Wait for VM to be accessible on a port
 -g, --shutdown             - Guest OS shutdown (format: -s off -g)
 -r, --recursive            - Recurse down through sub-folders to the specified folder to find the VM


### PR DESCRIPTION
This is a trivial doc change, the far-easier half of #477 's goals (the other one being an error message for incorrect usage, maybe).  This one just corrects the documentation to avoid the silently-failing case.  So easy.

### Description

A super-trivial doc fix.  Really, I just kept forgetting, and falling into the trap.

