### PR TITLE
Optimize our requires

### DIFF
--- a/lib/chef/knife/helpers/base_vsphere_command.rb
+++ b/lib/chef/knife/helpers/base_vsphere_command.rb
@@ -23,9 +23,9 @@ class Chef
       deps do
         require "rbvmomi"
         Chef::Knife::Bootstrap.load_deps
-        require "base64"
+        require "base64" unless defined?(Base64)
         require "filesize"
-        require "socket"
+        require "socket" unless defined?(Socket)
         require "net/ssh/multi"
         require "readline"
         require "chef/json_compat"

--- a/lib/chef/knife/vsphere_hosts_list.rb
+++ b/lib/chef/knife/vsphere_hosts_list.rb
@@ -8,7 +8,7 @@ class Chef::Knife::VsphereHostsList < Chef::Knife::BaseVsphereCommand
 
   deps do
     Chef::Knife::BaseVsphereCommand.load_deps
-    require "netaddr"
+    require "netaddr" unless defined?(NetAddr)
   end
 
   common_options

--- a/lib/chef/knife/vsphere_pool_query.rb
+++ b/lib/chef/knife/vsphere_pool_query.rb
@@ -7,7 +7,7 @@ class Chef::Knife::VspherePoolQuery < Chef::Knife::BaseVsphereCommand
 
   deps do
     Chef::Knife::BaseVsphereCommand.load_deps
-    require "netaddr"
+    require "netaddr" unless defined?(NetAddr)
   end
 
   common_options

--- a/lib/chef/knife/vsphere_pool_show.rb
+++ b/lib/chef/knife/vsphere_pool_show.rb
@@ -6,7 +6,7 @@ class Chef::Knife::VspherePoolShow < Chef::Knife::BaseVsphereCommand
 
   deps do
     Chef::Knife::BaseVsphereCommand.load_deps
-    require "netaddr"
+    require "netaddr" unless defined?(NetAddr)
   end
 
   common_options

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -15,9 +15,9 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
 
   deps do
     Chef::Knife::BaseVsphereCommand.load_deps
-    require "ipaddr"
-    require "netaddr"
-    require "securerandom"
+    require "ipaddr" unless defined?(IPAddr)
+    require "netaddr" unless defined?(NetAddr)
+    require "securerandom" unless defined?(SecureRandom)
     require "chef/json_compat"
 
     require_relative "helpers/search_helper"

--- a/lib/chef/knife/vsphere_vm_network_add.rb
+++ b/lib/chef/knife/vsphere_vm_network_add.rb
@@ -25,7 +25,7 @@ class Chef::Knife::VsphereVmNetworkAdd < Chef::Knife::BaseVsphereCommand
     required: false
 
   deps do
-    require "netaddr"
+    require "netaddr" unless defined?(NetAddr)
   end
 
   common_options


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>