### PR TITLE
Fix password prompting

### DIFF
--- a/lib/chef/knife/helpers/base_vsphere_command.rb
+++ b/lib/chef/knife/helpers/base_vsphere_command.rb
@@ -122,7 +122,7 @@ class Chef
       end
 
       def get_password_from_stdin
-        @password ||= ui.ask("Enter your password: ") { |q| q.echo = false }
+        @password ||= ui.ask("Enter your password: ") { |q| q.echo(false) }
       end
 
       def traverse_folders_for_pools(folder)


### PR DESCRIPTION
When a password is not provided and we prompt for it in
`get_password_from_stdin` we were dumping a stack trace.

This fixes that by using Question.echo(val) instead of Question.echo =
val, which is not valid for the TTY::Prompt API.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
