### PR TITLE
Use rbvmomi2 gem

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -24,7 +24,15 @@ steps:
       docker:
         image: ruby:3.0-buster
 
-- label: run-specs-windows
+- label: run-lint-and-specs-ruby-3.1
+  command:
+    - .expeditor/run_linux_tests.sh rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.1-buster
+
+- label: run-specs-windows-ruby-2.7
   command:
     - bundle config --local path vendor/bundle
     - bundle config set --local without docs debug
@@ -33,4 +41,26 @@ steps:
   expeditor:
     executor:
       docker:
-        host_os: windows
+        image: rubydistros/windows-2019:2.7
+
+- label: run-specs-windows-ruby-3.0
+  command:
+    - bundle config --local path vendor/bundle
+    - bundle config set --local without docs debug
+    - bundle install --jobs=7 --retry=3
+    - bundle exec rake
+  expeditor:
+    executor:
+      docker:
+        image: rubydistros/windows-2019:3.0
+
+- label: run-specs-windows-ruby-3.1
+  command:
+    - bundle config --local path vendor/bundle
+    - bundle config set --local without docs debug
+    - bundle install --jobs=7 --retry=3
+    - bundle exec rake
+  expeditor:
+    executor:
+      docker:
+        image: rubydistros/windows-2019:3.1

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -41,6 +41,7 @@ steps:
   expeditor:
     executor:
       docker:
+        host_os: windows
         image: rubydistros/windows-2019:2.7
 
 - label: run-specs-windows-ruby-3.0
@@ -52,6 +53,7 @@ steps:
   expeditor:
     executor:
       docker:
+        host_os: windows
         image: rubydistros/windows-2019:3.0
 
 - label: run-specs-windows-ruby-3.1
@@ -63,4 +65,5 @@ steps:
   expeditor:
     executor:
       docker:
+        host_os: windows
         image: rubydistros/windows-2019:3.1

--- a/knife-vsphere.gemspec
+++ b/knife-vsphere.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/chef/knife-vsphere"
   s.license = "Apache-2.0"
   s.add_dependency "netaddr", "~> 1.5"
-  s.add_dependency "rbvmomi2", ">= 1.8", "< 4.0"
+  s.add_dependency "rbvmomi2", ">= 3.5.0", "< 4.0"
   s.add_dependency "filesize", ">= 0.1.1", "< 0.3.0"
   s.add_dependency "chef-vault", ">= 2.6"
   s.add_dependency "knife", ">= 17"

--- a/knife-vsphere.gemspec
+++ b/knife-vsphere.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/chef/knife-vsphere"
   s.license = "Apache-2.0"
   s.add_dependency "netaddr", "~> 1.5"
-  s.add_dependency "rbvmomi", ">= 1.8", "< 4.0"
+  s.add_dependency "rbvmomi2", ">= 1.8", "< 4.0"
   s.add_dependency "filesize", ">= 0.1.1", "< 0.3.0"
   s.add_dependency "chef-vault", ">= 2.6"
   s.add_dependency "knife", ">= 17"


### PR DESCRIPTION
Signed-off-by: Ashique P S <Ashique.saidalavi@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The API wrapper gem used in knife-vsphere is `rbvmomi` and it is currently in the public archive and there isn't any development going on. Luckily someone from the community has forked this gem and fixed some of the known issues and published a new version as `rbvmomi2`. 

In this PR, updated the gem spec to use the new gem as a dependency. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
