### PR TITLE
CHEF-26923 - standardize - remove_sla_from_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,8 @@
-﻿# knife vSphere
+# knife vSphere
 
 [![Gem Version](https://badge.fury.io/rb/knife-vsphere.svg)](https://rubygems.org/gems/knife-vsphere)
 [![Build status](https://badge.buildkite.com/b68210c9f6436b2275b9365b0fe9ccdce80bd41a79f62424ac.svg?branch=master)](https://buildkite.com/chef-oss/chef-knife-vsphere-master-verify)
 [![Inline docs](http://inch-ci.org/github/chef/knife-vsphere.svg?branch=master)](http://inch-ci.org/github/chef/knife-vsphere)
-
-**Umbrella Project**: [Knife](https://github.com/chef/chef-oss-practices/blob/master/projects/knife.md)
-
- **Project State**: [Active](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md#active)
-
- **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md)**: 14 days
-
- **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md)**: 14 days
 
 Please refer to the [CHANGELOG](CHANGELOG) for version history and known issues.
 


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.

This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025). 
As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md).